### PR TITLE
Update LibAFL deps and nightly toolchain

### DIFF
--- a/fuzzingengine/Cargo.toml
+++ b/fuzzingengine/Cargo.toml
@@ -59,12 +59,11 @@ ethers = "2.0.7"
 
 hex = "0.4"
 primitive-types = { version = "0.12.1", features = ["rlp", "serde"] }
-libafl = "=0.11.1"
-libafl_bolts = "=0.11.1"
+libafl = "=0.15.3"
+libafl_bolts = "=0.15.3"
 rand = "0.8.5"
 nix = "0.27.1"
 serde = "1.0.147"
-serde_traitobject = "0.2.8"
 serde_json = "1.0.73"
 z3 = { version = "0.12.0", features = ["static-link-z3"] }
 z3-sys = "0.8.1"

--- a/fuzzingengine/rust-toolchain.toml
+++ b/fuzzingengine/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-11-01"
+channel = "nightly-2025-07-01"

--- a/fuzzingengine/src/evm/abi.rs
+++ b/fuzzingengine/src/evm/abi.rs
@@ -187,7 +187,6 @@ where
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct BoxedABI {
     /// ABI wrapper
-    // #[serde(with = "serde_traitobject")]
     pub b: Box<dyn ABI>,
     /// Function hash, if it is 0x00000000, it means the function hash is not
     /// set or this is to resume execution from a previous control leak

--- a/fuzzingengine/src/input.rs
+++ b/fuzzingengine/src/input.rs
@@ -21,7 +21,7 @@ use crate::{
 
 /// A trait for VM inputs that are sent to any smart contract VM
 pub trait VMInputT<VS, Loc, Addr, CI>:
-    Input + Debug + Clone + serde_traitobject::Serialize + serde_traitobject::Deserialize
+    Input + Debug + Clone + Serialize + DeserializeOwned
 where
     VS: Default + VMStateT,
     Addr: Debug + Clone + Serialize + DeserializeOwned,


### PR DESCRIPTION
## Summary
- bump LibAFL and LibAFL-bolts to 0.15.3
- use the `nightly-2025-07-01` toolchain for compiling
- drop `serde_traitobject` usage and use standard `Serialize`/`DeserializeOwned`

## Testing
- `cargo check` *(fails: too many dependencies to compile within time limit)*

------
https://chatgpt.com/codex/tasks/task_e_6868a813b788832d9d1594583dbc3a2d